### PR TITLE
add pre-commit hook, fixes #494

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "description": "Absorb the Orbs!",
   "main": "server/server.js",
   "scripts": {
-    "test": "exit 0",
+    "test": "npm run eslint",
     "start": "./node_modules/.bin/supervisor --watch server,common,package.json server/server.js",
     "debug": "node-debug --web-port 8088 server/server.js",
     "start-prod": "node server/server.js dist",
@@ -14,7 +14,9 @@
     "build-upload": "bash build.sh --upload",
     "uglify-theirs": "./node_modules/.bin/uglifyjs -o client/js/third.min.js",
     "uglify-ours": "./node_modules/.bin/uglifyjs -o client/js/first.min.js --wrap ZOR -m -c --mangle-props regex=\"/^z_|^ZOR/\"",
-    "eslint": "./node_modules/.bin/eslint server client/js client/skins common tests/*.js"
+    "pre-commit-msg": "echo 'Running pre-commit tests...' && exit 0",
+    "eslint": "./node_modules/.bin/eslint server client/js client/skins common tests/*.js",
+    "precommit": "npm test"
   },
   "author": "Scripta Games, Inc.",
   "dependencies": {
@@ -54,6 +56,7 @@
     "autoprefixer": "7.1.1",
     "eslint": "4.8.0",
     "eslint-config-google": "0.9.1",
+    "git-pre-commit": "^2.1.3",
     "html-inline": "1.2.0",
     "html-minifier": "3.5.2",
     "less": "2.7.2",


### PR DESCRIPTION
@Jared-Sprague voila!  set it up to use "npm test" as the precommit hook, which in turn runs the eslint script.  `npm install` required.